### PR TITLE
Add support for streaming to v4l2

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ seek_viewer
 Some example command lines:
 
 ```
-seek_viewer --camtype=seekpro --colormap=11 --rotate=0                     # view color mapped thermal video
-seek_viewer --camtype=seekpro --colormap=11 --rotate=0 --output=seek.avi   # record color mapped thermal video
+seek_viewer --camtype=seekpro --colormap=11 --rotate=0                                  # view color mapped thermal video
+seek_viewer --camtype=seekpro --colormap=11 --rotate=0 --mode=file --output=seek.avi    # record color mapped thermal video
 ```
 
 ## Linking the library to another program


### PR DESCRIPTION
I've added this functionality directly into the viewer example. I could however factor this out to a separate file if that helps to keep these examples easier to understand. While technically this should be able to stream to any v4l2 output I've only tested it with v4l2loopback. 

The second colorspace conversion and use of RGB for v4l2 output is chosen due to [extremely narrow](https://chromium.googlesource.com/chromium/src/media/+/refs/heads/master/capture/video/linux/v4l2_capture_delegate.cc#67) color space support in Chromium. I think a bunch of people might be interested in using this to stream IR to video chat applications.