### PR TITLE
Manipulate colormap, contrast, brightness & window position

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,22 @@ Pressing 'r' will change the orientation (4 possible)
 By providing the '-n 1' command line switch, brightness and contrast are no longer adjusted dynamically. 
 
 'w'  will increase the contast
+
 's'  will decrease the contrast
+
 'a'  will decrease the brightness
+
 'd'  will increase the brightness
 
 This function provides quite granular control, but this also means brightness has to be tweaked to match for each adjustment to contrast. 
 It is useful for having the field of vision not suddendly change in appearance completely when a hot or cold object is viewed.
+
+### Scaling
+One can also adjust the size of the output (scaling value) by pressing + or -.
+Note that in this case, "+" means Shift + "=" and "-" is just the normal "-" key. The Numpad "+" and "-" return different scan codes so don't work at this time.
+
+### Window position
+At least on Ubuntu (will check Debian later) the arrow keys allow moving the window position. Scancodes are different for each platform (supposedly for different renderers even), so this may not work on your environment.
+
+## Feedback
+I've started a thread about this updated version on EEVBlog, please comment for questions / issues: https://www.eevblog.com/forum/thermal-imaging/slightly-updated-libseek-thermal-(keyboard-interface)/

--- a/README.md
+++ b/README.md
@@ -149,3 +149,20 @@ seek_viewer -t seek -F seek_ffc.png
 seek_test_pro seekpro_ffc.png
 seek_viewer -t seekpro -F seekpro_ffc.png
 ```
+## Added functionality
+### Color map selecting
+Cycle through all 12 color maps by pressing 'c'. Black and white is not a standard "colormap" but it is preseved at the 0th position, for a total of 13 possible maps.
+
+###Rotating
+Pressing 'r' will change the orientation (4 possible)
+
+### Brightness & contrast
+By providing the '-n 1' command line switch, brightness and contrast are no longer adjusted dynamically. 
+
+'w'  will increase the contast
+'s'  will decrease the contrast
+'a'  will decrease the brightness
+'d'  will increase the brightness
+
+This function provides quite granular control, but this also means brightness has to be tweaked to match for each adjustment to contrast. 
+It is useful for having the field of vision not suddendly change in appearance completely when a hot or cold object is viewed.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ seek_viewer -t seekpro -F seekpro_ffc.png
 ### Color map selecting
 Cycle through all 12 color maps by pressing 'c'. Black and white is not a standard "colormap" but it is preseved at the 0th position, for a total of 13 possible maps.
 
-###Rotating
+### Rotating
 Pressing 'r' will change the orientation (4 possible)
 
 ### Brightness & contrast

--- a/examples/seek_viewer.cpp
+++ b/examples/seek_viewer.cpp
@@ -49,8 +49,8 @@ frame_g16=(inframe*cont)-bright;
         resize(frame_g8, frame_g8, Size(), scale, scale, INTER_LINEAR);
 
     // Apply colormap: http://docs.opencv.org/3.2.0/d3/d50/group__imgproc__colormap.html#ga9a805d8262bcbe273f16be9ea2055a65
-    if (colormap != -1) {
-        applyColorMap(frame_g8, outframe, colormap);
+    if (colormap != 0) {
+        applyColorMap(frame_g8, outframe, colormap-1);
     } else {
         cv::cvtColor(frame_g8, outframe, cv::COLOR_GRAY2BGR);
     }
@@ -203,7 +203,15 @@ int main(int argc, char** argv)
 		}else{
 		colormap=0;
 	}
-	}else {
+	}else if(c==114){
+		if(rotate==270){
+			rotate=0;
+		}
+		else{
+			rotate+=90;
+		}
+	}
+	else {
             writer << outframe;
         }
 	}

--- a/examples/seek_viewer.cpp
+++ b/examples/seek_viewer.cpp
@@ -210,8 +210,11 @@ int main(int argc, char** argv)
 		else{
 			rotate+=90;
 		}
-	}
-	else {
+	}else if(c==43){
+		scale +=0.05;
+	}else if(c==45){
+		scale -=0.05;
+	}else {
             writer << outframe;
         }
 	}

--- a/examples/seek_viewer.cpp
+++ b/examples/seek_viewer.cpp
@@ -58,7 +58,8 @@ frame_g16=(inframe*cont)-bright;
 
 int main(int argc, char** argv)
 {
-    // Setup arguments for parser
+	    
+// Setup arguments for parser
     args::ArgumentParser parser("Seek Thermal Viewer");
     args::HelpFlag help(parser, "help", "Display this help menu", {'h', "help"});
     args::ValueFlag<std::string> _output(parser, "output", "Output Stream - name of the video file to write", {'o', "output"});
@@ -72,7 +73,8 @@ int main(int argc, char** argv)
     int colormap=0;
     int brightness=0;
     int normalize=0;
-
+    int x=100;
+    int y=100;	
     // Parse arguments
     try
     {
@@ -185,7 +187,10 @@ int main(int argc, char** argv)
 
         if (output == "window") {
             imshow("SeekThermal", outframe);
-            char c = waitKey(5)&0xFF;
+		namedWindow("SeekThermal");
+		moveWindow("SeekThermal", x,y);
+            int c = waitKeyEx(5);
+		//std::cout << (int)c << std::endl;
             if (c == 112) {
                 waitKey(0);
             }
@@ -193,10 +198,10 @@ int main(int argc, char** argv)
 		normalize++;
 	} else if (c ==115 && _normalize){
 		normalize--;
-	} else if (c == 100 && _normalize){
-		brightness+=5000;
-	}else if (c == 97 && _normalize){
+	} else if (c == 100 && _normalize){  // normally 100
 		brightness-=5000;
+	}else if (c == 97 && _normalize){    //normally 97
+		brightness+=5000;
 	}else if(c == 99){
 		if(colormap<12){
 			colormap++;
@@ -210,10 +215,18 @@ int main(int argc, char** argv)
 		else{
 			rotate+=90;
 		}
-	}else if(c==43){
+	}else if(c==65579){
 		scale +=0.05;
 	}else if(c==45){
 		scale -=0.05;
+	}else if(c==65362){
+		y-=10;
+	}else if(c==65364){
+		y+=10;
+	}else if(c==65363){
+		x+=10;
+	}else if(c==65361){
+		x-=10;
 	}else {
             writer << outframe;
         }


### PR DESCRIPTION
I created this so I can change the appearance of the output window on-the-fly. The colormap, brightness & contrast can be cycled through manually and the window position & size can be moved with the arrow or +/- keys (the arrows might need some work - I don't know how to make key scancode access generic).