### PR TITLE
Fix warning (wrong initialization order)

### DIFF
--- a/src/SeekCam.cpp
+++ b/src/SeekCam.cpp
@@ -16,12 +16,12 @@ SeekCam::SeekCam(int vendor_id, int product_id, uint16_t* buffer, size_t raw_hei
     m_dev(vendor_id, product_id),
     m_raw_data(buffer),
     m_raw_data_size(raw_height * raw_width),
+    m_request_size(request_size),
     m_raw_frame(raw_height,
                 raw_width,
                 CV_16UC1,
                 buffer,
                 cv::Mat::AUTO_STEP),
-    m_request_size(request_size),
     m_flat_field_calibration_frame(),
     m_additional_ffc(),
     m_dead_pixel_mask()


### PR DESCRIPTION
Hello,

The fix is a simple one liner, and the title explains everything. 

Thanks a lot for sharing your code. I'm currently waiting for a compact pro (stolen while delavery, but I expect Ama... to solve that) and I'll be back soon for something else.



FYI, the warnings below:

````
me@my_machine $HOME/Devel/CAMERA_THERMIQUE/libseek-thermal/build $ cmake ..
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Setting build type to 'Release' as none was specified.
-- Build type: Release
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.1") 
-- Found OpenCV: /usr/local (found version "3.4.0") 

-----------------------------------------------------------------------------
-- The following external packages were located on your system.
-- This installation will have the extra features provided by these packages.
-----------------------------------------------------------------------------
   * libusb - Required to communicate via USB
   * OpenCV - Required to handle image processing

-----------------------------------------------------------------------------
-- Congratulations! All external packages have been found.
-----------------------------------------------------------------------------

-- Configuring done
-- Generating done
-- Build files have been written to: $HOME/Devel/CAMERA_THERMIQUE/libseek-thermal/build
Scanning dependencies of target seek
[  5%] Building CXX object src/CMakeFiles/seek.dir/SeekCam.cpp.o
In file included from $HOME/Devel/CAMERA_THERMIQUE/libseek-thermal/src/SeekCam.cpp:6:0:
$HOME/Devel/CAMERA_THERMIQUE/libseek-thermal/src/SeekCam.h: In constructor ‘LibSeek::SeekCam::SeekCam(int, int, uint16_t*, size_t, size_t, size_t, cv::Rect, std::__cxx11::string)’:
$HOME/Devel/CAMERA_THERMIQUE/libseek-thermal/src/SeekCam.h:88:13: warning: ‘LibSeek::SeekCam::m_raw_frame’ will be initialized after [-Wreorder]
     cv::Mat m_raw_frame;
             ^~~~~~~~~~~
$HOME/Devel/CAMERA_THERMIQUE/libseek-thermal/src/SeekCam.h:87:12: warning:   ‘size_t LibSeek::SeekCam::m_request_size’ [-Wreorder]
     size_t m_request_size;
            ^~~~~~~~~~~~~~
$HOME/Devel/CAMERA_THERMIQUE/libseek-thermal/src/SeekCam.cpp:12:1: warning:   when initialized here [-Wreorder]
 SeekCam::SeekCam(int vendor_id, int product_id, uint16_t* buffer, size_t raw_height, size_t raw_width, size_t request_size, cv::Rect roi, std::string ffc_filename) :

````

