### PR TITLE
Close seekdevice when the seekcam is closed

### DIFF
--- a/src/SeekCam.cpp
+++ b/src/SeekCam.cpp
@@ -65,6 +65,7 @@ void SeekCam::close()
         m_dev.request_set(DeviceCommand::SET_OPERATION_MODE, data);
         m_dev.request_set(DeviceCommand::SET_OPERATION_MODE, data);
         m_dev.request_set(DeviceCommand::SET_OPERATION_MODE, data);
+        m_dev.close();
     }
     m_is_opened = false;
 }


### PR DESCRIPTION
This should fix #28. Camera can be closed and opened as needed with this addition.